### PR TITLE
Fix variable name typo

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -312,7 +312,7 @@ module.exports = (robot) ->
                   else
                     "#{user.name}"
 
-      msg.send "Sorry, I can't figure out #{possesive} email address :( Can #{addressee} tell me with `#{robot.name} pager me as you@yourdomain.com`?"
+      msg.send "Sorry, I can't figure out #{possessive} email address :( Can #{addressee} tell me with `#{robot.name} pager me as you@yourdomain.com`?"
       return
 
     pagerDutyGet msg, "/users", {query: email}, (json) ->


### PR DESCRIPTION
Greetings!

It looks like there was a typo when referencing the `possessive` variable when a user has not identified their PagerDuty email address, which would raise an exception:

```
Hubot> hubot pager ack!
[Tue Jul 15 2014 19:30:50 GMT+0000 (UTC)] ERROR ReferenceError: possesive is not defined
  at campfireUserToPagerDutyUser (/home/driti/dev/hubot-pager-me/src/scripts/pagerduty.coffee:318:7, <js>:363:49)
  at updateIncidents (/home/driti/dev/hubot-pager-me/src/scripts/pagerduty.coffee:486:5, <js>:545:14)
  at /home/driti/dev/hubot-pager-me/src/scripts/pagerduty.coffee:150:7, <js>:163:16
  at /home/driti/dev/hubot-pager-me/src/scripts/pagerduty.coffee:440:7, <js>:513:16
  at /home/driti/dev/hubot-pager-me/src/scripts/pagerduty.coffee:345:9, <js>:397:16
  at IncomingMessage.<anonymous> (/home/driti/dev/myhubot/node_modules/hubot/node_modules/scoped-http-client/lib/index.js:70:20)
  at IncomingMessage.emit (events.js:117:20)
  at _stream_readable.js:929:16
  at process._tickCallback (node.js:419:13)
```

This pull request fixes the issue! If you have any question or concerns, please let me know! Thanks in advance :smile: 
