### PR TITLE
Renames variable

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -555,7 +555,7 @@ module.exports = (robot) ->
           escalationPolicy = json.escalation_policies[0]
         else if json?.escalation_policies?.length > 1
           matchingExactly = json.escalation_policies.filter (es) ->
-            es.name == q
+            es.name == string
           if matchingExactly.length == 1
             escalationPolicy = matchingExactly[0]
 


### PR DESCRIPTION
It seems like during a refactoring `q` became `string` but wasn't updated here
