### PR TITLE
Fix /pager trigger when user has email address, but no PagerDuty user found for it

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -440,8 +440,12 @@ module.exports = (robot) ->
 
     pagerDutyGet msg, "/users", {query: email}, (json) ->
       if json.users.length isnt 1
-        msg.send "Sorry, I expected to get 1 user back for #{email}, but got #{json.users.length} :sweat:. Can you make sure that is actually a real user on PagerDuty?"
-        return
+        if json.users.length is 0 and not required
+          cb null
+          return
+        else
+          msg.send "Sorry, I expected to get 1 user back for #{email}, but got #{json.users.length} :sweat:. Can you make sure that is actually a real user on PagerDuty?"
+          return
 
       cb(json.users[0])
 


### PR DESCRIPTION
This is a followup to https://github.com/hubot-scripts/hubot-pager-me/pull/20 . That addressed doing `/pager me trigger` when your user doesn't have any email associated with it (like using campfire shell). If you are using Campfire and some other adapters, it defaults to your user's email address on the chat service, which might not be your correct address. When a PagerDuty user isn't found for that email address, /pager trigger failed.

This applies the `not required` logic for when there is a configured email address, but it doesn't result in any found pagerduty users.
