### PR TITLE
Less noise on a non-match

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -677,7 +677,7 @@ module.exports = (robot) ->
             foundIncidents.push(incident)
 
         if foundIncidents.length == 0
-          msg.reply "Couldn't find incidents #{incidentNumbers.join(', ')} in #{inspect incidents}"
+          msg.reply "Couldn't find incident(s) #{incidentNumbers.join(', ')}. Use `#{robot.name} pager incidents` for listing."
         else
           # loljson
           data = {


### PR DESCRIPTION
 Prior to this PR, using `hubot pager ack PMTZY` (as one might think is the ID of an incident) resulted in a terrible flood of text, caused by the code using the `inspect` method on a large array of hashes. As there is already a command to get a formatted list of open incidents, this is not needed.
 
 **Example of Inspect Behavior**
 ![](http://cl.ly/image/320e2O1o1A2s/Image%202015-02-19%20at%2010.27.15%20PM.png)
 