### PR TITLE
Restrict queries to a particular service

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Then add **hubot-pager-me** to your `external-scripts.json`:
 * HUBOT_PAGERDUTY_USER_ID - The user id of a PagerDuty user for your bot. This is only required if you want chat users to be able to trigger incidents without their own PagerDuty user
 * HUBOT_PAGERDUTY_API_KEY - Get one from https://<your subdomain>.pagerduty.com/api_keys
 * HUBOT_PAGERDUTY_SERVICE_API_KEY - Service API Key from a 'General API Service'. This should be assigned to a dummy escalation policy that doesn't actually notify, as hubot will trigger on this before reassigning it
+* HUBOT_PAGERDUTY_SERVICES - (optional) Provide a comma separated list of service identifiers (e.g. `PFGPBFY`) to restrict queries to only those services.
 
 ### Webhook
 

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -43,6 +43,7 @@ pagerDutyApiKey        = process.env.HUBOT_PAGERDUTY_API_KEY
 pagerDutySubdomain     = process.env.HUBOT_PAGERDUTY_SUBDOMAIN
 pagerDutyBaseUrl       = "https://#{pagerDutySubdomain}.pagerduty.com/api/v1"
 pagerDutyServiceApiKey = process.env.HUBOT_PAGERDUTY_SERVICE_API_KEY
+pagerDutyServices      = process.env.HUBOT_PAGERDUTY_SERVICES
 pagerRoom              = process.env.HUBOT_PAGERDUTY_ROOM
 # Webhook listener endpoint. Set it to whatever URL you want, and make sure it matches your pagerduty service settings
 pagerEndpoint          = process.env.HUBOT_PAGERDUTY_ENDPOINT || "/hook"
@@ -453,6 +454,9 @@ module.exports = (robot) ->
   pagerDutyGet = (msg, url, query, cb) ->
     if missingEnvironmentForApi(msg)
       return
+
+    if pagerDutyServices? && url.match /\/incidents/
+      query['service'] = pagerDutyServices
 
     auth = "Token token=#{pagerDutyApiKey}"
     msg.http(pagerDutyBaseUrl + url)


### PR DESCRIPTION
Fixes #31

Our PagerDuty instance has numerous services that receive alerts, but we only want our Hubot to query against a subset of those. This adds a `HUBOT_PAGERDUTY_SERVICES` environment variable that accepts a comma separated list of service identifiers. This list is then added as a `service` key on all of the `pagerDutyGet` method calls to apply that filter.

Reference: https://developer.pagerduty.com/documentation/rest/incidents/list