### PR TITLE
Allow case-insensitive matches for "pager me incident NNN"

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -78,7 +78,7 @@ module.exports = (robot) ->
     msg.message.user.pagerdutyEmail = undefined
     msg.send "Okay, I've forgotten your PagerDuty email"
 
-  robot.respond /(pager|major)( me)? incident (.*)$/, (msg) ->
+  robot.respond /(pager|major)( me)? incident (.*)$/i, (msg) ->
     pagerDutyIncident msg, msg.match[3], (incident) ->
       msg.send formatIncident(incident)
 


### PR DESCRIPTION
Hi!  We use this Hubot script a lot, but noticed that the "pager me incident NNN" command doesn't work in our environment.  After debugging it turned out that it was because of the mixed-case robot name we use and the fact that the regexp pattern for this command didn't end in `/i` like all the other `robot.respond` patterns.

This makes the regexp pattern for this command more similar to the others:
```
~/hubot-pager-me/src/scripts$ git grep robot.respond
pagerduty.coffee:  robot.respond /pager( me)?$/i, (msg) ->
pagerduty.coffee:  robot.respond /pager(?: me)? as (.*)$/i, (msg) ->
pagerduty.coffee:  robot.respond /pager forget me$/i, (msg) ->
pagerduty.coffee:  robot.respond /(pager|major)( me)? incident (.*)$/i, (msg) ->
pagerduty.coffee:  robot.respond /(pager|major)( me)? (inc|incidents|sup|problems)$/i, (msg) ->
pagerduty.coffee:  robot.respond /(pager|major)( me)? (?:trigger|page) ([\w\-]+)$/i, (msg) ->
pagerduty.coffee:  robot.respond /(pager|major)( me)? (?:trigger|page) ([\w\-]+) (.+)$/i, (msg) ->
pagerduty.coffee:  robot.respond /(?:pager|major)(?: me)? ack(?:nowledge)? (.+)$/i, (msg) ->
pagerduty.coffee:  robot.respond /(pager|major)( me)? ack(nowledge)?(!)?$/i, (msg) ->
pagerduty.coffee:  robot.respond /(?:pager|major)(?: me)? res(?:olve)?(?:d)? (.+)$/i, (msg) ->
pagerduty.coffee:  robot.respond /(pager|major)( me)? res(olve)?(d)?(!)?$/i, (msg) ->
pagerduty.coffee:  robot.respond /(pager|major)( me)? notes (.+)$/i, (msg) ->
pagerduty.coffee:  robot.respond /(pager|major)( me)? note ([\d\w]+) (.+)$/i, (msg) ->
pagerduty.coffee:  robot.respond /(pager|major)( me)? schedules( (.+))?$/i, (msg) ->
pagerduty.coffee:  robot.respond /(pager|major)( me)? (schedule|overrides)( ([\w\-]+))?( ([^ ]+))?$/i, (msg) ->
pagerduty.coffee:  robot.respond /(pager|major)( me)? (override) ([\w\-]+) ([\w\-:\+]+) - ([\w\-:\+]+)( (.*))?$/i, (msg) ->
pagerduty.coffee:  robot.respond /(pager|major)( me)? (overrides?) ([\w\-]*) (delete) (.*)$/i, (msg) ->
pagerduty.coffee:  robot.respond /pager( me)? (.+) (\d+)$/i, (msg) ->
pagerduty.coffee:  robot.respond /who('s|s| is|se)? (on call|oncall|on-call)( (?:for )?(.+))?/i, (msg) ->
```