### PR TITLE
Restore the original 'pager sup' format for nagios alerts

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -645,15 +645,15 @@ module.exports = (robot) ->
      #   HOSTSTATE: 'UP' },
 
     summary = if inc.trigger_summary_data
-              # email services
-              if inc.trigger_summary_data.subject
-                inc.trigger_summary_data.subject
-              else if inc.trigger_summary_data.description
-                inc.trigger_summary_data.description
-              else if inc.trigger_summary_data.pd_nagios_object == 'service'
+              if inc.trigger_summary_data.pd_nagios_object == 'service'
                  "#{inc.trigger_summary_data.HOSTNAME}/#{inc.trigger_summary_data.SERVICEDESC}"
               else if inc.trigger_summary_data.pd_nagios_object == 'host'
                  "#{inc.trigger_summary_data.HOSTNAME}/#{inc.trigger_summary_data.HOSTSTATE}"
+              # email services
+              else if inc.trigger_summary_data.subject
+                inc.trigger_summary_data.subject
+              else if inc.trigger_summary_data.description
+                inc.trigger_summary_data.description
               else
                 ""
             else


### PR DESCRIPTION
The original format was something like

```
Triggered:
----------

Acknowledged:
-------------
2858: 2014-12-19T04:46:54Z host1/unknown-services (CRITICAL) - assigned to antonio
2859: 2014-12-19T04:47:14Z host2/haproxy-status (CRITICAL) - assigned to antonio
```

but since mid December the `/` between the host and the check description has been replaced by a space.

A subject is always returned (this was probably not always the case before) and the first condition patch in the `if` clause setting the summary is always met. Reordering the condition branches is enough to get the original format back.