### PR TITLE
Allows on-call queries to be case-insensitive

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -598,10 +598,10 @@ module.exports = (robot) ->
       if json?.schedules?.length == 1
         schedule = json.schedules[0]
 
-      # Multiple results returned and one is exact
+      # Multiple results returned and one is exact (case-insensitive)
       if json?.schedules?.length > 1
         matchingExactly = json.schedules.filter (s) ->
-          s.name == q
+          s.name.toLowerCase() == q.toLowerCase()
         if matchingExactly.length == 1
           schedule = matchingExactly[0]
       cb(schedule)
@@ -625,9 +625,10 @@ module.exports = (robot) ->
 
         if json?.escalation_policies?.length == 1
           escalationPolicy = json.escalation_policies[0]
+        # Multiple results returned and one is exact (case-insensitive)
         else if json?.escalation_policies?.length > 1
           matchingExactly = json.escalation_policies.filter (es) ->
-            es.name == string
+            es.name.toLowerCase() == string.toLowerCase()
           if matchingExactly.length == 1
             escalationPolicy = matchingExactly[0]
 


### PR DESCRIPTION
Fixes #40

Prior to this PR, asking an on-call question, such as `hubot who is on call for devops` would only produce a result if the name of the PagerDuty schedule was exactly "devops", but not if it were "DevOps". This PR converts the query text and result set item to lowercase, allowing a more permissive match.