### PR TITLE
Fix deprecation warning from Moment.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.node-version

--- a/package.json
+++ b/package.json
@@ -21,15 +21,18 @@
     "moment-timezone": "~0.4.0"
   },
   "devDependencies": {
-    "mocha": "~2.2.5",
-    "chai": ">=1.9.2 <3",
-    "sinon-chai": "*",
-    "sinon": "*",
-    "grunt-mocha-test": "~0.7.0",
-    "grunt-release": "~0.6.0",
-    "matchdep": "~0.1.2",
-    "grunt-contrib-watch": "~0.5.3"
-
+    "chai": "^2.1.1",
+    "coffee-script": "1.6.3",
+    "grunt": "^0.4.5",
+    "grunt-cli": "^0.1.13",
+    "grunt-contrib-watch": "~0.6.1",
+    "grunt-mocha-test": "~0.12.7",
+    "grunt-release": "~0.11.0",
+    "hubot": "2.x",
+    "matchdep": "~0.3.0",
+    "mocha": "^2.1.0",
+    "sinon": "^1.13.0",
+    "sinon-chai": "^2.7.0"
   },
   "main": "index.coffee",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -18,17 +18,18 @@
   },
   "dependencies": {
     "coffee-script": "~1.6",
-    "moment-timezone": "~0.2.2"
+    "moment-timezone": "~0.4.0"
   },
   "devDependencies": {
-    "mocha": "*",
-    "chai": "*",
+    "mocha": "~2.2.5",
+    "chai": ">=1.9.2 <3",
     "sinon-chai": "*",
     "sinon": "*",
     "grunt-mocha-test": "~0.7.0",
     "grunt-release": "~0.6.0",
     "matchdep": "~0.1.2",
     "grunt-contrib-watch": "~0.5.3"
+
   },
   "main": "index.coffee",
   "scripts": {

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -259,7 +259,7 @@ module.exports = (robot) ->
   robot.respond /(pager|major)( me)? (schedule|overrides)( ([\w\-]+))?( ([^ ]+))?$/i, (msg) ->
     query = {
       since: moment().format(),
-      until: moment().add('days', 30).format(),
+      until: moment().add(30, 'days').format(),
       overflow: 'true'
     }
 
@@ -367,7 +367,7 @@ module.exports = (robot) ->
 
         start     = moment().format()
         minutes   = parseInt msg.match[3]
-        end       = moment().add('minutes', minutes).format()
+        end       = moment().add(minutes, 'minutes').format()
         override  = {
           'start':     start,
           'end':       end,
@@ -646,7 +646,7 @@ module.exports = (robot) ->
       cb(user.name, s)
 
   withCurrentOncallUser = (msg, schedule, cb) ->
-    oneHour = moment().add('hours', 1).format()
+    oneHour = moment().add(1, 'hours').format()
     now = moment().format()
 
     query = {

--- a/test/pager-me-test.coffee
+++ b/test/pager-me-test.coffee
@@ -12,5 +12,65 @@ describe 'pagerduty', ->
 
     require('../src/scripts/pagerduty')(@robot)
 
-  it 'compiles', ->
-    true
+  it 'registers a pager me listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/pager( me)?$/i)
+
+  it 'registers a pager me as listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/pager(?: me)? as (.*)$/i)
+
+  it 'registers a pager forget me listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/pager forget me$/i)
+
+  it 'registers a pager indcident listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/(pager|major)( me)? incident (.*)$/i)
+
+  it 'registers a pager sup listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/(pager|major)( me)? (inc|incidents|sup|problems)$/i)
+
+  it 'registers a pager trigger listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/(pager|major)( me)? (?:trigger|page) ([\w\-]+)$/i)
+
+  it 'registers a pager trigger with message listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/(pager|major)( me)? (?:trigger|page) ([\w\-]+) (.+)$/i)
+
+  it 'registers a pager ack listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/(?:pager|major)(?: me)? ack(?:nowledge)? (.+)$/i)
+
+  it 'registers a pager ack! listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/(pager|major)( me)? ack(nowledge)?(!)?$/i)
+
+  it 'registers a pager resolve listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/(?:pager|major)(?: me)? res(?:olve)?(?:d)? (.+)$/i)
+
+  it 'registers a pager resolve! listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/(pager|major)( me)? res(olve)?(d)?(!)?$/i)
+
+  it 'registers a pager notes on listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/(pager|major)( me)? notes (.+)$/i)
+
+  it 'registers a pager notes add listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/(pager|major)( me)? note ([\d\w]+) (.+)$/i)
+
+  it 'registers a pager schedules listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/(pager|major)( me)? schedules( (.+))?$/i)
+
+  it 'registers a pager schedule override listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/(pager|major)( me)? (schedule|overrides)( ([\w\-]+))?( ([^ ]+))?$/i)
+
+  it 'registers a pager schedule override details listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/(pager|major)( me)? (override) ([\w\-]+) ([\w\-:\+]+) - ([\w\-:\+]+)( (.*))?$/i)
+
+  it 'registers a pager override delete listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/(pager|major)( me)? (overrides?) ([\w\-]*) (delete) (.*)$/i)
+
+  it 'registers a pager link listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/pager( me)? (.+) (\d+)$/i)
+
+  it 'registers a pager on call listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/who('s|s| is|se)? (on call|oncall|on-call)( (?:for )?(.+))?/i)
+
+  it 'registers a pager services listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/(pager|major)( me)? services$/i)
+
+  it 'registers a pager maintenance listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/(pager|major)( me)? maintenance (\d+) (.+)$/i)


### PR DESCRIPTION
Prior to this PR, a user may encounter the message below in their console. This is the result of a deprecation warning thrown in `Moment.js`, where the preferred order of arguments has been swapped.

>Deprecation warning: moment().add(period, number) is deprecated. Please use moment().add(number, period).

- Registers tests, fixes testing harness to reslove an issue with Sinon/Chai
- Fixes deprecation notice that has crept in with updates
- Bumps moment-timezone version to latest release