### PR TITLE
Allow smart quotes in who's on call command

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -382,7 +382,7 @@ module.exports = (robot) ->
 
 
   # who is on call?
-  robot.respond /who('s|s| is|se)? (on call|oncall|on-call)( (?:for )?(.+))?/i, (msg) ->
+  robot.respond /who(’s|'s|s| is|se)? (on call|oncall|on-call)( (?:for )?(.+))?/i, (msg) ->
     scheduleName = msg.match[4]
 
     displaySchedule = (s) ->


### PR DESCRIPTION
Mac users (on the Hubot-Slack integration at least) often have trouble with the "who's on call" command, since the default OS X settings will convert quotation marks into angled quotation marks: `“”` and `‘’` .

This change simply recognizes the angled single quote that automatically gets rendered when Mac users type out the command:

`hubot who’s on call`