### PR TITLE
Only send one message for who's on call

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/hubot-scripts/hubot-pager-me/issues"
   },
   "dependencies": {
+    "async": "^1.4.2",
     "coffee-script": "~1.6",
     "moment-timezone": "~0.4.0",
     "scoped-http-client": "^0.11.0"

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -561,12 +561,14 @@ module.exports = (robot) ->
 
     scheduleName = msg.match[4]
 
-    displaySchedule = (s) ->
+    renderSchedule = (s, cb) ->
       withCurrentOncall msg, s, (username, schedule) ->
-        msg.send "* #{username} is on call for #{schedule.name} - https://#{pagerduty.subdomain}.pagerduty.com/schedules##{schedule.id}\n"
+        cb "* #{username} is on call for #{schedule.name} - https://#{pagerduty.subdomain}.pagerduty.com/schedules##{schedule.id}"
 
     if scheduleName?
-      withScheduleMatching msg, scheduleName, displaySchedule
+      withScheduleMatching msg, scheduleName, (s) ->
+        renderSchedule s, (text) ->
+          msg.send text
     else
       pagerduty.getSchedules (err, schedules) ->
         if err?
@@ -575,7 +577,8 @@ module.exports = (robot) ->
 
         if schedules.length > 0
           for s in schedules
-            displaySchedule(s)
+            renderSchedule s, (text) ->
+              msg.send text
         else
           msg.send 'No schedules found!'
 


### PR DESCRIPTION
One problem I've found with `who's on call` is that it sends one message per schedule that matches. That means flooding 20 messages if you have 20 schedules.

This uses the `async` library to gather the schedules, and send them out as one message instead.