### PR TITLE
Fix ack and ack! commands

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -187,7 +187,7 @@ module.exports = (robot) ->
 
     force = msg.match[4]?
 
-    pagerduty.getIncidents 'triggered,acknwowledged', (err, incidents) ->
+    pagerduty.getIncidents 'triggered,acknowledged', (err, incidents) ->
       if err?
         robot.emit 'error', err, msg
         return


### PR DESCRIPTION
Typo in acknowledged was causing validation error and command would not complete. Looks like a change in validation on Pagerduty's side.

Request response was 
```
{"error":
  {"message":"Invalid Input Provided",
   "code":2001,
   "errors":["Status must be a list of triggered, acknowledged, or resolved."]
}}
```
---
Fixes #57