### PR TITLE
Export subdomain

### DIFF
--- a/src/pagerduty.coffee
+++ b/src/pagerduty.coffee
@@ -136,3 +136,5 @@ module.exports =
         return
 
       cb(null, json.schedules)
+
+  subdomain: pagerDutySubdomain


### PR DESCRIPTION
When PR #52 was merged the subdomain wasn't exported in src/pagerduty.coffee. It is referenced in src/scripts/pagerduty.coffee as pagerduty.subdomain