### PR TITLE
Fix error when multiple schedules match who's on call

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -692,7 +692,7 @@ module.exports = (robot) ->
 
       # Multiple results returned and one is exact (case-insensitive)
       if schedules?.length > 1
-        matchingExactly = json.schedules.filter (s) ->
+        matchingExactly = schedules.filter (s) ->
           s.name.toLowerCase() == q.toLowerCase()
         if matchingExactly.length == 1
           schedule = matchingExactly[0]


### PR DESCRIPTION
Hubot> hubot who's on call for platform
    Hubot> [Wed Nov 04 2015 09:27:53 GMT-0600 (CST)] ERROR ReferenceError: json is not defined
      at /Users/matt/work/hungrybot/node_modules/hubot-pager-me/src/scripts/pagerduty.coffee:695:9, <js>:780:29
      at /Users/matt/work/hungrybot/node_modules/hubot-pager-me/src/pagerduty.coffee:138:7, <js>:185:16
      at /Users/matt/work/hungrybot/node_modules/hubot-pager-me/src/pagerduty.coffee:46:9, <js>:76:16
      at IncomingMessage.<anonymous> (/Users/matt/work/hungrybot/node_modules/scoped-http-client/src/index.js:95:22)

It would be nice if it listed the names of the matching schedules, but for now let's just fix this bug