### PR TITLE
Fix who's on call subdomain link

### DIFF
--- a/src/pagerduty.coffee
+++ b/src/pagerduty.coffee
@@ -136,3 +136,5 @@ module.exports =
         return
 
       cb(null, json.schedules)
+
+  subdomain: pagerDutySubdomain

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -560,7 +560,7 @@ module.exports = (robot) ->
 
     renderSchedule = (s, cb) ->
       withCurrentOncall msg, s, (username, schedule) ->
-        cb null, "* #{username} is on call for #{schedule.name} - https://#{pagerduty.domain}.pagerduty.com/schedules##{schedule.id}"
+        cb null, "* #{username} is on call for #{schedule.name} - https://#{pagerduty.subdomain}.pagerduty.com/schedules##{schedule.id}"
 
     if scheduleName?
       withScheduleMatching msg, scheduleName, (s) ->


### PR DESCRIPTION
Who's on call was returning undefined for subdomain
https://undefined.pagerduty.com/schedules#P3SEAWV

https://github.com/hubot-scripts/hubot-pager-me/pull/58 has part of the
fix in adding subdomain to export, but didn't change `domain` to
`subdomain` in the usage