### PR TITLE
Show who's on call for all matching schedules

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -677,7 +677,7 @@ module.exports = (robot) ->
 
       cb(json.users[0])
 
-  oneScheduleMatching = (msg, q, cb) ->
+  SchedulesMatching = (msg, q, cb) ->
     query = {
       query: q
     }
@@ -686,26 +686,12 @@ module.exports = (robot) ->
         robot.emit 'error', err, msg
         return
 
-      # Single result returned
-      if schedules?.length == 1
-        schedule = schedules[0]
-
-      # Multiple results returned and one is exact (case-insensitive)
-      if schedules?.length > 1
-        matchingExactly = json.schedules.filter (s) ->
-          s.name.toLowerCase() == q.toLowerCase()
-        if matchingExactly.length == 1
-          schedule = matchingExactly[0]
-      cb(schedule)
+      cb(schedules)
 
   withScheduleMatching = (msg, q, cb) ->
-    oneScheduleMatching msg, q, (schedule) ->
-      if schedule
-        cb(schedule)
-      else
-        # maybe look for a specific name match here?
-        msg.send "I couldn't determine exactly which schedule you meant by #{q}. Can you be more specific?"
-        return
+    SchedulesMatching msg, q, (schedules) ->
+      cb(schedule) for schedule in schedules
+      return
 
   reassignmentParametersForUserOrScheduleOrEscalationPolicy = (msg, string, cb) ->
     if campfireUser = robot.brain.userForName(string)

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -690,7 +690,11 @@ module.exports = (robot) ->
 
   withScheduleMatching = (msg, q, cb) ->
     SchedulesMatching msg, q, (schedules) ->
-      cb(schedule) for schedule in schedules
+      if schedules?.length < 1
+        msg.send "I couldn't find any schedules matching #{q}"
+      else
+        msg.send schedule for schedule in schedules
+        cb(schedule) for schedule in schedules
       return
 
   reassignmentParametersForUserOrScheduleOrEscalationPolicy = (msg, string, cb) ->


### PR DESCRIPTION
This is a lot friendlier than just saying "I couldn't determine exactly
which schedule you meant".  Unless I know the exact schedule name I
might not be able to figure out how to get the on call person to show.
I also often want to know who's on call for multiple teams that match a
string since we have multiple "platform" teams that I oversee.

Only issue I can see here is if someone has a *lot* of schedules this
might spam the chat with all the matches.  I would imagine this is an
edge case that might not even matter, especially since 'hubot pager
schedules foo` would already have that issue since it prints all the
matching schedules.