### PR TITLE
Fixing rouge variable in schedule lookup.

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -721,7 +721,7 @@ module.exports = (robot) ->
         if escalationPolicy?
           cb(escalation_policy: escalationPolicy.id, name: escalationPolicy.name)
         else
-          oneScheduleMatching msg, string, (schedule) ->
+          SchedulesMatching msg, string, (schedule) ->
             if schedule
               withCurrentOncallUser msg, schedule, (user, schedule) ->
                 cb(assigned_to_user: user.id,  name: user.name)


### PR DESCRIPTION
Tested and this fixes the `hubot pager schedule $schedule` lookup in [issue 64](https://github.com/hubot-scripts/hubot-pager-me/issues/64)