### PR TITLE
Fix #67 matching schedules by removing debug output

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -693,7 +693,6 @@ module.exports = (robot) ->
       if schedules?.length < 1
         msg.send "I couldn't find any schedules matching #{q}"
       else
-        msg.send schedule for schedule in schedules
         cb(schedule) for schedule in schedules
       return
 


### PR DESCRIPTION
I left some debugging in place that was messaging objects.  This doesn't
blow up in the console, but does once you get to real adapters like
slack.