### PR TITLE
Add ability to specify days when looking up schedules/overrides

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -25,11 +25,11 @@
 #   hubot pager resolve! - resolve all acknowledged, not just yours
 #   hubot pager schedules - list schedules
 #   hubot pager schedules <search> - list schedules matching <search>
-#   hubot pager schedule <schedule> - show <schedule>'s shifts for the upcoming month
-#   hubot pager my schedule - show my on call shifts for the upcoming month in all schedules
+#   hubot pager schedule <schedule> <days> - show <schedule>'s shifts for the next <days> (default 30 days)
+#   hubot pager my schedule <days> - show my on call shifts for the upcoming <days> in all schedules (default 30 days)
 #   hubot pager me <schedule> <minutes> - take the pager for <minutes> minutes
 #   hubot pager override <schedule> <start> - <end> [username] - Create an schedule override from <start> until <end>. If [username] is left off, defaults to you. start and end should date-parsable dates, like 2014-06-24T09:06:45-07:00, see http://momentjs.com/docs/#/parsing/string/ for examples.
-#   hubot pager overrides <schedule> - show upcoming overrides for the next month
+#   hubot pager overrides <schedule> <days> - show upcoming overrides for the next x <days> (default 30 days)
 #   hubot pager override <schedule> delete <id> - delete an override by its ID
 #   hubot pager services - list services
 #   hubot pager maintenance <minutes> <service_id1> <service_id2> ... <service_idN> - schedule a maintenance window for <minutes> for specified services
@@ -316,13 +316,18 @@ module.exports = (robot) ->
       else
         msg.send 'No schedules found!'
 
-  robot.respond /(pager|major)( me)? (schedule|overrides)( ([\w\-]+))?( ([^ ]+))?$/i, (msg) ->
+  robot.respond /(pager|major)( me)? (schedule|overrides)( ([\w\-]+))?( ([^ ]+)\s*(\d+)?)?$/i, (msg) ->
     if pagerduty.missingEnvironmentForApi(msg)
       return
 
+    if msg.match[8]
+      days = msg.match[8]
+    else
+      days = 30
+
     query = {
       since: moment().format(),
-      until: moment().add(30, 'days').format(),
+      until: moment().add(days, 'days').format(),
       overflow: 'true'
     }
 
@@ -368,16 +373,21 @@ module.exports = (robot) ->
         else
           msg.send "None found!"
 
-  robot.respond /(pager|major)( me)? my schedule( ([^ ]+))?$/i, (msg) ->
+  robot.respond /(pager|major)( me)? my schedule( ([^ ]+)\s?(\d+))?$/i, (msg) ->
     if pagerduty.missingEnvironmentForApi(msg)
       return
+
+    if msg.match[5]
+      days = msg.match[5]
+    else
+      days = 30
 
     campfireUserToPagerDutyUser msg, msg.message.user, (user) ->
       userId = user.id
 
       query = {
         since: moment().format(),
-        until: moment().add(30, 'days').format(),
+        until: moment().add(days, 'days').format(),
         overflow: 'true'
       }
 
@@ -480,7 +490,7 @@ module.exports = (robot) ->
         else
           msg.send "Something went weird."
 
-  robot.respond /pager( me)? (.+) (\d+)$/i, (msg) ->
+  robot.respond /pager( me)? (?!schedules?\b|overrides?\b|my schedule\b)(.+) (\d+)$/i, (msg) ->
     msg.finish()
 
     if pagerduty.missingEnvironmentForApi(msg)

--- a/test/pager-me-test.coffee
+++ b/test/pager-me-test.coffee
@@ -55,7 +55,7 @@ describe 'pagerduty', ->
     expect(@robot.respond).to.have.been.calledWith(/(pager|major)( me)? schedules( (.+))?$/i)
 
   it 'registers a pager schedule override listener', ->
-    expect(@robot.respond).to.have.been.calledWith(/(pager|major)( me)? (schedule|overrides)( ([\w\-]+))?( ([^ ]+))?$/i)
+    expect(@robot.respond).to.have.been.calledWith(/(pager|major)( me)? (schedule|overrides)( ([\w\-]+))?( ([^ ]+)\s*(\d+)?)?$/i)
 
   it 'registers a pager schedule override details listener', ->
     expect(@robot.respond).to.have.been.calledWith(/(pager|major)( me)? (override) ([\w\-]+) ([\w\-:\+]+) - ([\w\-:\+]+)( (.*))?$/i)
@@ -64,7 +64,7 @@ describe 'pagerduty', ->
     expect(@robot.respond).to.have.been.calledWith(/(pager|major)( me)? (overrides?) ([\w\-]*) (delete) (.*)$/i)
 
   it 'registers a pager link listener', ->
-    expect(@robot.respond).to.have.been.calledWith(/pager( me)? (.+) (\d+)$/i)
+    expect(@robot.respond).to.have.been.calledWith(/pager( me)? (?!schedules?\b|overrides?\b|my schedule\b)(.+) (\d+)$/i)
 
   it 'registers a pager on call listener', ->
     expect(@robot.respond).to.have.been.calledWith(/who(’s|'s|s| is|se)? (on call|oncall|on-call)( (?:for )?(.+))?/i)


### PR DESCRIPTION
This adds the ability to specify days when looking up schedules and overrides:

Get the last 4 days of oncall schedule:
```
devbot> devbot pager schedule First UTC 4
* 2015-11-26T23:45:12+00:00 - 2015-11-27T00:59:00+00:00 user 1
* 2015-11-27T00:59:00+00:00 - 2015-11-27T12:59:00+00:00 user 2
* 2015-11-27T12:59:00+00:00 - 2015-11-28T00:59:00+00:00 user 1
* 2015-11-28T00:59:00+00:00 - 2015-11-30T12:59:00+00:00 user 2
* 2015-11-30T12:59:00+00:00 - 2015-12-01T00:59:00+00:00 user 3
```

Last 14 days of 
```
devbot> devbot pager overrides First UTC 14
* (Q1GT8JQBWNDME7) 2015-11-26T12:59:00+00:00 - 2015-11-27T00:59:00+00:00 user 4
```

We have 12 hour shifts in our schedules spanning different timezones, so 30 days fills the scrollback.

I had to alter the `pager me <schedule> <minutes>` regex to disregard other commands that can now also end with digits, but this still works are normal.... providing your schedule is not specifically called `schedule`,`schedules`,`override`,`overrides` or `my schedule`. I'm keen to hear feedback on if there is a better way to do this.