### PR TITLE
who's on call will return a block rather than individual mesages

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -570,7 +570,7 @@ module.exports = (robot) ->
 
     scheduleName = msg.match[1]
 
-    messages = ["/code"]
+    messages = []
     renderSchedule = (s, cb) ->
       withCurrentOncall msg, s, (username, schedule) ->
         cb null, messages.push("* #{username} is on call for #{schedule.name} - https://#{pagerduty.subdomain}.pagerduty.com/schedules##{schedule.id}")

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -76,7 +76,7 @@ module.exports = (robot) ->
 
   robot.respond /(pager|major)( me)? incident (.*)$/i, (msg) ->
     msg.finish()
-    
+
     if pagerduty.missingEnvironmentForApi(msg)
       return
 
@@ -570,9 +570,13 @@ module.exports = (robot) ->
 
     scheduleName = msg.match[1]
 
+    messages = ["/code"]
     renderSchedule = (s, cb) ->
       withCurrentOncall msg, s, (username, schedule) ->
-        cb null, "* #{username} is on call for #{schedule.name} - https://#{pagerduty.subdomain}.pagerduty.com/schedules##{schedule.id}"
+        cb null, messages.push("* #{username} is on call for #{schedule.name} - https://#{pagerduty.subdomain}.pagerduty.com/schedules##{schedule.id}")
+    setTimeout ( ->
+      msg.send messages.join("\n")
+    ), 1500
 
     if scheduleName?
       withScheduleMatching msg, scheduleName, (s) ->
@@ -586,7 +590,6 @@ module.exports = (robot) ->
         if err?
           robot.emit 'error', err, msg
           return
-
         if schedules.length > 0
           async.map schedules, renderSchedule, (err, results) ->
             if err?


### PR DESCRIPTION
The "who's on call" functionality intermittently works when the return payload is particularly large - sometimes returning only partial results, sometimes working perfectly, and sometimes returning nothing at all.

This PR address the issue of who's on call sending each returned item as an individual message by waiting for all results to be received and then concatenating them together. As an aside, it seems to fix the intermittent nature of the functionality due to hanging async requests, as described in https://github.com/hubot-scripts/hubot-pager-me/issues/43.