### PR TITLE
Flip the order of schedule and username

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -573,7 +573,7 @@ module.exports = (robot) ->
     messages = []
     renderSchedule = (s, cb) ->
       withCurrentOncall msg, s, (username, schedule) ->
-        cb null, messages.push("* #{username} is on call for #{schedule.name} - https://#{pagerduty.subdomain}.pagerduty.com/schedules##{schedule.id}")
+        cb null, messages.push("* #{schedule.name}'s oncall is #{username} - https://#{pagerduty.subdomain}.pagerduty.com/schedules##{schedule.id}")
     setTimeout ( ->
       msg.send messages.join("\n")
     ), 1500


### PR DESCRIPTION
When running `/who's oncall` you want to scan down the list for the schedule names not the usernames, the individual oncall for a given schedule is secondary information.

/cc @technicalpickles for review