### PR TITLE
Fix who's on call output

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -573,10 +573,8 @@ module.exports = (robot) ->
     messages = []
     renderSchedule = (s, cb) ->
       withCurrentOncall msg, s, (username, schedule) ->
-        cb null, messages.push("* #{username} is on call for #{schedule.name} - https://#{pagerduty.subdomain}.pagerduty.com/schedules##{schedule.id}")
-    setTimeout ( ->
-      msg.send messages.join("\n")
-    ), 1500
+        messages.push("* #{username} is on call for #{schedule.name} - https://#{pagerduty.subdomain}.pagerduty.com/schedules##{schedule.id}")
+        cb null
 
     if scheduleName?
       withScheduleMatching msg, scheduleName, (s) ->
@@ -591,11 +589,11 @@ module.exports = (robot) ->
           robot.emit 'error', err, msg
           return
         if schedules.length > 0
-          async.map schedules, renderSchedule, (err, results) ->
+          async.map schedules, renderSchedule, (err) ->
             if err?
               robot.emit 'error', err, msg
               return
-            msg.send results.join("\n")
+            msg.send messages.join("\n")
         else
           msg.send 'No schedules found!'
 


### PR DESCRIPTION
Found that running `who's on call` will give some garbage output:

```
hubot> hubot who's on call
4
6
5
3
1
2
7
8
* Foo Bar is on call for Example - Engineering - https://foo.pagerduty.com/schedules#PSH77FE
* Baz Biz is on call for Example - DEV - https://foo.pagerduty.com/schedules#chedules#PQ4T39J
```

Traced this back to ef1d84bd where the output was changed to return in a
single message rather several. Both the results of `messages.push()`
which is the length of the array and the actual `messages` array itself
was being sent back.