### PR TITLE
Add ability to transform a certain char to a space

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Then add **hubot-pager-me** to your `external-scripts.json`:
 * HUBOT_PAGERDUTY_API_KEY - Get one from https://<your subdomain>.pagerduty.com/api_keys
 * HUBOT_PAGERDUTY_SERVICE_API_KEY - Service API Key from a 'General API Service'. This should be assigned to a dummy escalation policy that doesn't actually notify, as hubot will trigger on this before reassigning it
 * HUBOT_PAGERDUTY_SERVICES - (optional) Provide a comma separated list of service identifiers (e.g. `PFGPBFY`) to restrict queries to only those services.
+* HUBOT_PAGERDUTY_CHAR_TO_SPACE - (optional) Provide a character that will be transformed into a space. For example, if you specify `_` here then entering something like `pager trigger Foo_Bar testing` will transform the schedule to `Foo Bar`.
 
 ### Webhook
 
@@ -109,7 +110,7 @@ hubot-pager-me makes some assumptions about how you are using PagerDuty:
 
 * PagerDuty email matches chat email
   * override with `hubot pager me as <pagerduty email>`
-* Schedules' and Escalation Policies' names are letters and dashes (no spaces, digits)
+* Schedules' and Escalation Policies' names are letters, numbers, dashes and underscores. Spaces are also possible with `HUBOT_PAGERDUTY_CHAR_TO_SPACE`
 * The Service used by hubot-pager-me should not be assigned to an escalation policy with real people on it. Instead, it should be a dummy user that doesn't have any notification rules. If this isn't done, the escalation policy assigned to it will be notified, and then hubot will immediately reassign to the proper team
 
 ## Development

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -44,6 +44,7 @@ moment = require('moment-timezone')
 
 pagerDutyUserId        = process.env.HUBOT_PAGERDUTY_USER_ID
 pagerDutyServiceApiKey = process.env.HUBOT_PAGERDUTY_SERVICE_API_KEY
+pagerDutyCharToSpace   = process.env.HUBOT_PAGERDUTY_CHAR_TO_SPACE
 
 module.exports = (robot) ->
 
@@ -702,6 +703,7 @@ module.exports = (robot) ->
       cb(schedules)
 
   withScheduleMatching = (msg, q, cb) ->
+    q = transformCharToSpace q
     SchedulesMatching msg, q, (schedules) ->
       if schedules?.length < 1
         msg.send "I couldn't find any schedules matching #{q}"
@@ -710,6 +712,7 @@ module.exports = (robot) ->
       return
 
   reassignmentParametersForUserOrScheduleOrEscalationPolicy = (msg, string, cb) ->
+    string = transformCharToSpace string
     if campfireUser = robot.brain.userForName(string)
       campfireUserToPagerDutyUser msg, campfireUser, (user) ->
         cb(assigned_to_user: user.id,  name: user.name)
@@ -813,6 +816,12 @@ module.exports = (robot) ->
 
 
     "#{inc.incident_number}: #{inc.created_on} #{summary} #{assigned_to}\n"
+
+  transformCharToSpace = (string) ->
+    if pagerDutyCharToSpace?
+      string = string.replace(pagerDutyCharToSpace, ' ')
+
+    return string
 
   updateIncidents = (msg, incidentNumbers, statusFilter, updatedStatus) ->
     campfireUserToPagerDutyUser msg, msg.message.user, (user) ->


### PR DESCRIPTION
Added `HUBOT_PAGERDUTY_CHAR_TO_SPACE` option which allows for converting
a specific char into a space. For example, by setting this option to `_`
this will transform `Foo_Bar` to `Foo Bar`. This is useful for anyone
who has usernames or schedules that contain spaces and do not wish to
change them. Here is a more verbose example:

```
hubot> pager trigger Foo_Bar testing
```

This will trigger the `Foo Bar` schedule.