### PR TITLE
Send the messages array for who's oncall w/ team name

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -582,7 +582,7 @@ module.exports = (robot) ->
           if err?
             robot.emit 'error'
             return
-          msg.send text
+          msg.send messages.join("\n")
     else
       pagerduty.getSchedules (err, schedules) ->
         if err?

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -582,7 +582,7 @@ module.exports = (robot) ->
           if err?
             robot.emit 'error'
             return
-          msg.send messages.join("\n")
+          msg.send messages[messages.length - 1]
     else
       pagerduty.getSchedules (err, schedules) ->
         if err?


### PR DESCRIPTION
If we request who's oncall for a specific team; we get unhandled exceptions and "undefined" returned. 

Replacing this line fixes it for us. 