### PR TITLE
Add ability to handle spaces in names

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,6 @@ hubot-pager-me makes some assumptions about how you are using PagerDuty:
 
 * PagerDuty email matches chat email
   * override with `hubot pager me as <pagerduty email>`
-* Schedules' and Escalation Policies' names are letters and dashes (no spaces, digits)
 * The Service used by hubot-pager-me should not be assigned to an escalation policy with real people on it. Instead, it should be a dummy user that doesn't have any notification rules. If this isn't done, the escalation policy assigned to it will be notified, and then hubot will immediately reassign to the proper team
 
 ## Development

--- a/test/pager-me-test.coffee
+++ b/test/pager-me-test.coffee
@@ -5,6 +5,10 @@ chai.use require 'sinon-chai'
 expect = chai.expect
 
 describe 'pagerduty', ->
+  before ->
+    @triggerRegex = /(pager|major)( me)? (?:trigger|page) ((["'])([^]*?)\4|([\w\-]+)) (.+)$/i
+    @schedulesRegex = /(pager|major)( me)? schedules( ((["'])([^]*?)\5|(.+)))?$/i
+
   beforeEach ->
     @robot =
       respond: sinon.spy()
@@ -31,7 +35,7 @@ describe 'pagerduty', ->
     expect(@robot.respond).to.have.been.calledWith(/(pager|major)( me)? (?:trigger|page) ([\w\-]+)$/i)
 
   it 'registers a pager trigger with message listener', ->
-    expect(@robot.respond).to.have.been.calledWith(/(pager|major)( me)? (?:trigger|page) ([\w\-]+) (.+)$/i)
+    expect(@robot.respond).to.have.been.calledWith(@triggerRegex)
 
   it 'registers a pager ack listener', ->
     expect(@robot.respond).to.have.been.calledWith(/(?:pager|major)(?: me)? ack(?:nowledge)? (.+)$/i)
@@ -52,16 +56,16 @@ describe 'pagerduty', ->
     expect(@robot.respond).to.have.been.calledWith(/(pager|major)( me)? note ([\d\w]+) (.+)$/i)
 
   it 'registers a pager schedules listener', ->
-    expect(@robot.respond).to.have.been.calledWith(/(pager|major)( me)? schedules( (.+))?$/i)
+    expect(@robot.respond).to.have.been.calledWith(@schedulesRegex)
 
   it 'registers a pager schedule override listener', ->
-    expect(@robot.respond).to.have.been.calledWith(/(pager|major)( me)? (schedule|overrides)( ([\w\-]+))?( ([^ ]+)\s*(\d+)?)?$/i)
+    expect(@robot.respond).to.have.been.calledWith(/(pager|major)( me)? (schedule|overrides)( ((["'])([^]*?)\6|([\w\-]+)))?( ([^ ]+)\s*(\d+)?)?$/i)
 
   it 'registers a pager schedule override details listener', ->
-    expect(@robot.respond).to.have.been.calledWith(/(pager|major)( me)? (override) ([\w\-]+) ([\w\-:\+]+) - ([\w\-:\+]+)( (.*))?$/i)
+    expect(@robot.respond).to.have.been.calledWith(/(pager|major)( me)? (override) ((["'])([^]*?)\5|([\w\-]+)) ([\w\-:\+]+) - ([\w\-:\+]+)( (.*))?$/i)
 
   it 'registers a pager override delete listener', ->
-    expect(@robot.respond).to.have.been.calledWith(/(pager|major)( me)? (overrides?) ([\w\-]*) (delete) (.*)$/i)
+    expect(@robot.respond).to.have.been.calledWith(/(pager|major)( me)? (overrides?) ((["'])([^]*?)\5|([\w\-]+)) (delete) (.*)$/i)
 
   it 'registers a pager link listener', ->
     expect(@robot.respond).to.have.been.calledWith(/pager( me)? (?!schedules?\b|overrides?\b|my schedule\b)(.+) (\d+)$/i)
@@ -74,3 +78,30 @@ describe 'pagerduty', ->
 
   it 'registers a pager maintenance listener', ->
     expect(@robot.respond).to.have.been.calledWith(/(pager|major)( me)? maintenance (\d+) (.+)$/i)
+
+  it 'trigger handles users with spaces', ->
+    msg = @triggerRegex.exec('pager trigger "foo bar" baz')
+    expect(msg[5]).to.equal('foo bar')
+    expect(msg[7]).to.equal('baz')
+
+  it 'trigger handles users with spaces and single quotes', ->
+    msg = @triggerRegex.exec("pager trigger 'foo bar' baz")
+    expect(msg[5]).to.equal('foo bar')
+    expect(msg[7]).to.equal('baz')
+
+  it 'trigger handles users without spaces', ->
+    msg = @triggerRegex.exec('pager trigger foo bar baz')
+    expect(msg[6]).to.equal('foo')
+    expect(msg[7]).to.equal('bar baz')
+
+  it 'schedules handles names with quotes', ->
+    msg = @schedulesRegex.exec('pager schedules "foo bar"')
+    expect(msg[6]).to.equal('foo bar')
+
+  it 'schedules handles names without quotes', ->
+    msg = @schedulesRegex.exec('pager schedules foo bar')
+    expect(msg[7]).to.equal('foo bar')
+
+  it 'schedules handles names without spaces', ->
+    msg = @schedulesRegex.exec('pager schedules foobar')
+    expect(msg[7]).to.equal('foobar')


### PR DESCRIPTION
Allow for using usernames and schedules that contain spaces by
encapsulating them in either single or double quotes. For example:

```
hubot> pager trigger "Foo Bar" testing
```