### PR TITLE
Fix "who is on call for xxx"

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -586,11 +586,11 @@ module.exports = (robot) ->
 
     if scheduleName?
       withScheduleMatching msg, scheduleName, (s) ->
-        renderSchedule s, (err, text) ->
+        renderSchedule s, (err) ->
           if err?
             robot.emit 'error'
             return
-          msg.send text
+          msg.send messages.join("\n")
     else
       pagerduty.getSchedules (err, schedules) ->
         if err?


### PR DESCRIPTION
commit c6f15fa713b627f262710d02240c5b70800d1e61 changed the signature
of the callback used in this command, and no longer passes the message.

Change the callback for the single schedule case to match the
all-schedules case and remove the unused parameter.