### PR TITLE
Fix email address reference in Slack adapter

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -194,7 +194,9 @@ module.exports = (robot) ->
         robot.emit 'error', err, msg
         return
 
-      email  = msg.message.user.pagerdutyEmail || msg.message.user.email_address
+      ## Determine the email based on the adapter type (v4.0.0+ of the Slack adapter stores it in `profile.email`)
+      email  = msg.message.user.pagerdutyEmail || msg.message.user.email_address || msg.message.user.profile.email
+
       filteredIncidents = if force
                             incidents # don't filter at all
                           else


### PR DESCRIPTION
The `user.profile.email` attribute seems to have won out over `user.email_address`. This PR allows an undefined value in the former to fall back to the latter.

- Reference: https://github.com/slackapi/hubot-slack/issues/367
- Fixes #102