### PR TITLE
Added Team filtering by team_ids for /incidents endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Then add **hubot-pager-me** to your `external-scripts.json`:
 | `HUBOT_PAGERDUTY_USER_ID`  | No`*`` | The user ID of a PagerDuty user for your bot. This is only required if you want chat users to be able to trigger incidents without their own PagerDuty user.
 | `HUBOT_PAGERDUTY_SERVICE_API_KEY` | No`*`` | The [Incident Service Key](https://v2.developer.pagerduty.com/docs/incident-creation-api) to use when creating a new incident. This should be assigned to a dummy escalation policy that doesn't actually notify, as Hubot will trigger on this before reassigning it.
 | `HUBOT_PAGERDUTY_SERVICES` | No | Provide a comma separated list of service identifiers (e.g. `PFGPBFY,AFBCGH`) to restrict queries to only those services. |
+| `HUBOT_PAGERDUTY_TEAMS` | No | Provide a comma separated list of teams identifiers (e.g. `PFGPBFY,AFBCGH`) to restrict queries to only those teams. You need teams function on |
 
 `*` - May be required for certain actions.
 

--- a/src/pagerduty.coffee
+++ b/src/pagerduty.coffee
@@ -5,6 +5,7 @@ pagerDutySubdomain     = process.env.HUBOT_PAGERDUTY_SUBDOMAIN
 pagerDutyBaseUrl       = 'https://api.pagerduty.com'
 pagerDutyServices      = process.env.HUBOT_PAGERDUTY_SERVICES
 pagerDutyFromEmail     = process.env.HUBOT_PAGERDUTY_FROM_EMAIL
+pagerDutyTeams         = process.env.HUBOT_PAGERDUTY_TEAMS
 pagerNoop              = process.env.HUBOT_PAGERDUTY_NOOP
 pagerNoop              = false if pagerNoop is 'false' or pagerNoop is 'off'
 
@@ -33,8 +34,11 @@ module.exports =
       cb = query
       query = {}
 
+    if pagerDutyTeams? && url.match /\/incidents/
+      query['teams_ids[]'] = pagerDutyTeams.split(',')
+
     if pagerDutyServices? && url.match /\/incidents/
-      query['service'] = pagerDutyServices
+      query['service_ids[]'] = pagerDutyServices.split(',')
 
     @http(url)
       .query(query)


### PR DESCRIPTION
- Fixed filtering by service. In https://v2.developer.pagerduty.com/v2/page/api-reference#!/Incidents/get_incidents is for service only `service_ids[]`