### PR TITLE
Make pager trigger unicode compatible

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -108,16 +108,15 @@ module.exports = (robot) ->
 
   robot.respond /(pager|major)( me)? (?:trigger|page) ([\w\-]+)$/i, (msg) ->
     msg.reply "Please include a user or schedule to page, like 'hubot pager infrastructure everything is on fire'."
-
-  robot.respond /(pager|major)( me)? (?:trigger|page) ((["'])([^]*?)\4|([\.\w\-]+)) (.+)$/i, (msg) ->
+  robot.respond /(pager|major)( me)? (?:trigger|page) ((["'])([^\4]*?)\4|“([^”]*?)”|‘([^’]*?)’|([\.\w\-]+)) (.+)$/i, (msg) ->
     msg.finish()
 
     if pagerduty.missingEnvironmentForApi(msg)
       return
 
     fromUserName = msg.message.user.name
-    query        = msg.match[5] or msg.match[6]
-    reason       = msg.match[7]
+    query        = msg.match[5] or msg.match[6] or msg.match[7] or msg.match[8]
+    reason       = msg.match[9]
     description  = "#{reason} - @#{fromUserName}"
 
     # Figure out who we are

--- a/test/pager-me-test.coffee
+++ b/test/pager-me-test.coffee
@@ -6,7 +6,7 @@ expect = chai.expect
 
 describe 'pagerduty', ->
   before ->
-    @triggerRegex = /(pager|major)( me)? (?:trigger|page) ((["'])([^]*?)\4|([\.\w\-]+)) (.+)$/i
+    @triggerRegex = /(pager|major)( me)? (?:trigger|page) ((["'])([^\4]*?)\4|“([^”]*?)”|‘([^’]*?)’|([\.\w\-]+)) (.+)$/i
     @schedulesRegex = /(pager|major)( me)? schedules( ((["'])([^]*?)\5|(.+)))?$/i
     @whosOnCallRegex = /who(?:’s|'s|s| is|se)? (?:on call|oncall|on-call)(?:\?)?(?: (?:for )?((["'])([^]*?)\2|(.*?))(?:\?|$))?$/i
 
@@ -82,23 +82,23 @@ describe 'pagerduty', ->
 
   it 'trigger handles users with dots', ->
     msg = @triggerRegex.exec('pager trigger foo.bar baz')
-    expect(msg[6]).to.equal('foo.bar')
-    expect(msg[7]).to.equal('baz')
+    expect(msg[8]).to.equal('foo.bar')
+    expect(msg[9]).to.equal('baz')
 
   it 'trigger handles users with spaces', ->
     msg = @triggerRegex.exec('pager trigger "foo bar" baz')
     expect(msg[5]).to.equal('foo bar')
-    expect(msg[7]).to.equal('baz')
+    expect(msg[9]).to.equal('baz')
 
   it 'trigger handles users with spaces and single quotes', ->
     msg = @triggerRegex.exec("pager trigger 'foo bar' baz")
     expect(msg[5]).to.equal('foo bar')
-    expect(msg[7]).to.equal('baz')
+    expect(msg[9]).to.equal('baz')
 
   it 'trigger handles users without spaces', ->
     msg = @triggerRegex.exec('pager trigger foo bar baz')
-    expect(msg[6]).to.equal('foo')
-    expect(msg[7]).to.equal('bar baz')
+    expect(msg[8]).to.equal('foo')
+    expect(msg[9]).to.equal('bar baz')
 
   it 'schedules handles names with quotes', ->
     msg = @schedulesRegex.exec('pager schedules "foo bar"')


### PR DESCRIPTION
Problem: Pager Trigger's regex isn't matching the quoted portion due to some modern OSes converting ASCII double quote and apostrophe to "left/right double quote" and "left/right single quote".  i.e. U+0022 gets converted to U+201C/U+201D and U+0027 gets converted to U+2018/U+2019.

Solution: Extend the regex to allow these unicode characters to delineate the PagerDuty schedule.