### PR TITLE
Added Schedules restrictions with  command who-s-on-call

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Then add **hubot-pager-me** to your `external-scripts.json`:
 | `HUBOT_PAGERDUTY_USER_ID`  | No`*`` | The user ID of a PagerDuty user for your bot. This is only required if you want chat users to be able to trigger incidents without their own PagerDuty user.
 | `HUBOT_PAGERDUTY_SERVICE_API_KEY` | No`*`` | The [Incident Service Key](https://v2.developer.pagerduty.com/docs/incident-creation-api) to use when creating a new incident. This should be assigned to a dummy escalation policy that doesn't actually notify, as Hubot will trigger on this before reassigning it.
 | `HUBOT_PAGERDUTY_SERVICES` | No | Provide a comma separated list of service identifiers (e.g. `PFGPBFY,AFBCGH`) to restrict queries to only those services. |
+| `HUBOT_PAGERDUTY_SCHEDULES` | No | Provide a comma separated list of schedules identifiers (e.g. `PFGPBFY,AFBCGH`) to restrict queries to only those schedules. |
 
 `*` - May be required for certain actions.
 

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -608,11 +608,14 @@ module.exports = (robot) ->
     scheduleName = msg.match[3] or msg.match[4]
 
     messages = []
-    allowed_schedules = pagerDutySchedules.split(",")
+    allowed_schedules = []
+    if pagerDutySchedules?
+      allowed_schedules = pagerDutySchedules.split(",")
+
     renderSchedule = (s, cb) ->
       withCurrentOncall msg, s, (username, schedule) ->
         if (username)
-          if !allowed_schedules or (allowed_schedules and schedule.id in allowed_schedules)
+          if !allowed_schedules or schedule.id in allowed_schedules
             messages.push("* #{username} is on call for #{schedule.name} - #{schedule.html_url}")
         else
           robot.logger.debug "No user for schedule #{schedule.name}"

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -44,6 +44,7 @@ moment = require('moment-timezone')
 
 pagerDutyUserId        = process.env.HUBOT_PAGERDUTY_USER_ID
 pagerDutyServiceApiKey = process.env.HUBOT_PAGERDUTY_SERVICE_API_KEY
+pagerDutySchedules     = process.env.HUBOT_PAGERDUTY_SCHEDULES
 
 module.exports = (robot) ->
 
@@ -607,10 +608,12 @@ module.exports = (robot) ->
     scheduleName = msg.match[3] or msg.match[4]
 
     messages = []
+    allowed_schedules = pagerDutySchedules.split(",")
     renderSchedule = (s, cb) ->
       withCurrentOncall msg, s, (username, schedule) ->
         if (username)
-          messages.push("* #{username} is on call for #{schedule.name} - #{schedule.html_url}")
+          if !allowed_schedules or (allowed_schedules and schedule.id in allowed_schedules)
+            messages.push("* #{username} is on call for #{schedule.name} - #{schedule.html_url}")
         else
           robot.logger.debug "No user for schedule #{schedule.name}"
         cb null


### PR DESCRIPTION
Added PagerDuty rescrition option (basic feature) to restrict the `who's on call` command.

Re: https://github.com/hubot-scripts/hubot-pager-me/issues/109#issuecomment-440433835