### PR TITLE
Fix duplicated on-call schedules when there are multiple matches

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -629,10 +629,10 @@ module.exports = (robot) ->
         cb null
 
     if scheduleName?
-      withScheduleMatching msg, scheduleName, (s) ->
-        renderSchedule s, (err) ->
+      SchedulesMatching msg, scheduleName, (s) ->
+        async.map s, renderSchedule, (err) ->
           if err?
-            robot.emit 'error'
+            robot.emit 'error', err, msg
             return
           msg.send messages.join("\n")
     else


### PR DESCRIPTION
This is a proper fix for the duplicated on-call schedule response when asking 'who is on call for <schedule>' -- it would loop through each match, and on each iteration it would push all of the matching schedules again.

Fixes https://github.com/hubot-scripts/hubot-pager-me/issues/95

## Testing done:
- who is on call for <query matching 1 schedule> ✅ 
_returns 1 schedule_
- who is on call for <query matching 2 schedules> ✅ 
_returns 2 schedules_
- who is on call ✅ 
_returns everything_