### PR TITLE
Switch from Travis CI to GitHub Actions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,26 @@
+name: Node CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 16.x]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: npm install, build, and test
+      run: |
+        npm install
+        npm run build --if-present
+        npm test
+      env:
+        CI: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-dist: xenial
-os: linux
-language: node_js
-node_js:
-  - "14" # stable
-  - "12" # LTS
-  - "10" # maintenance
-notifications:
-  email: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hubot-pager-me
 
-[![npm version](https://badge.fury.io/js/hubot-pager-me.svg)](http://badge.fury.io/js/hubot-pager-me) [![Build Status](https://travis-ci.org/hubot-scripts/hubot-pager-me.svg?branch=master)](https://travis-ci.org/hubot-scripts/hubot-pager-me)
+[![npm version](https://badge.fury.io/js/hubot-pager-me.svg)](http://badge.fury.io/js/hubot-pager-me) [![Node CI](https://github.com/hubot-scripts/hubot-pager-me/actions/workflows/nodejs.yml/badge.svg)](https://github.com/hubot-scripts/hubot-pager-me/actions/workflows/nodejs.yml)
 
 PagerDuty integration for Hubot.
 


### PR DESCRIPTION
Replaces existing automated CI, which started failing 6/15/2021.